### PR TITLE
Fixes crash in NetBeans Gradle when using JDK8

### DIFF
--- a/assignments/Asgn1-VideoUp/build.gradle
+++ b/assignments/Asgn1-VideoUp/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'spring-boot'
 apply plugin: 'war'
 
 compileJava {
+    sourceCompatibility = 1.7
     targetCompatibility = 1.7
 }
 


### PR DESCRIPTION
This will fix the compiler throwing an unhandled exception when building/running with the Gradle Support plug-in for NetBeans and you only have the latest JDK installed.
