### PR TITLE
Adding IntelliJ Idea project files to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ build
 .settings
 .classpath
 .private
+.idea
+*.iml
 coursera-submission


### PR DESCRIPTION
This is a small convenience for those of us using IntelliJ in the class - you've already ignored the Eclipse project metadata, so I think it makes sense to ignore the IntelliJ ones as well.
