### PR TITLE
Using empty contexts for the examples.

### DIFF
--- a/examples/1-SimpleServlet/README.md
+++ b/examples/1-SimpleServlet/README.md
@@ -15,7 +15,7 @@ and then type "jettyStop" for the task.
 After launching the EchoServlet, you can interact with it by opening a web
 browser to:
 
-http://localhost:8080/1-SimpleServlet/echo?msg=1234test
+http://localhost:8080/echo?msg=1234test
 
 Changing the "msg" URL query parameter will allow you to send different values
 to echo to the EchoServlet.

--- a/examples/1-SimpleServlet/build.gradle
+++ b/examples/1-SimpleServlet/build.gradle
@@ -6,6 +6,9 @@ apply plugin: 'jetty'
 stopPort = 8081 
 stopKey = 'stopKey'
 
+jettyRun.contextPath = ''
+jettyRunWar.contextPath = ''
+
 repositories {
     mavenCentral()
 }

--- a/examples/1-SimpleServlet/src/test/java/org/magnum/mobilecloud/servlet/test/EchoServletHttpTest.java
+++ b/examples/1-SimpleServlet/src/test/java/org/magnum/mobilecloud/servlet/test/EchoServletHttpTest.java
@@ -23,7 +23,7 @@ public class EchoServletHttpTest {
 	// By default, the test server will be running on localhost and listening to
 	// port 8080. If the server is running and you can't connect to it with this test,
 	// ensure that a firewall (e.g. Windows Firewall) isn't blocking access to it.
-	private final String TEST_URL = "http://localhost:8080/1-SimpleServlet/echo";
+	private final String TEST_URL = "http://localhost:8080/echo";
 	
 	/**
 	 * This test sends a GET request with a msg parameter and

--- a/examples/2-VideoServlet/README.md
+++ b/examples/2-VideoServlet/README.md
@@ -15,7 +15,7 @@ and then type "jettyStop" for the task.
 After launching the servlet, open your browser to the URL below to see a list of
 the videos that have been added:
 
-http://localhost:8080/2-VideoServlet/video
+http://localhost:8080/video
 
 In order to add a video that you can see in the list, run the VideoServletHttpTest
 JUnit test and then refresh your browser.

--- a/examples/2-VideoServlet/build.gradle
+++ b/examples/2-VideoServlet/build.gradle
@@ -6,6 +6,9 @@ apply plugin: 'jetty'
 stopPort = 8081 
 stopKey = 'stopKey'
 
+jettyRun.contextPath = ''
+jettyRunWar.contextPath = ''
+
 repositories {
     mavenCentral()
 }

--- a/examples/2-VideoServlet/src/test/java/org/magnum/mobilecloud/servlet/test/VideoServletHttpTest.java
+++ b/examples/2-VideoServlet/src/test/java/org/magnum/mobilecloud/servlet/test/VideoServletHttpTest.java
@@ -47,7 +47,7 @@ import org.magnum.mobilecloud.video.servlet.VideoServlet;
  */
 public class VideoServletHttpTest {
 
-	private final String TEST_URL = "http://localhost:8080/2-VideoServlet/video";
+	private final String TEST_URL = "http://localhost:8080/video";
 
 	// The HTTP client or "fake browser" that we are going to sue to send
 	// requests to the VideoServlet


### PR DESCRIPTION
As discussed on the forums, using empty contexts for single-servlet applications removes one step from the request routing and matches the lecture.
