### PR TITLE
Updated Video.java to use String for Id.

### DIFF
--- a/examples/10-VideoServiceWithMongoDB/src/main/java/org/magnum/mobilecloud/video/repository/Video.java
+++ b/examples/10-VideoServiceWithMongoDB/src/main/java/org/magnum/mobilecloud/video/repository/Video.java
@@ -14,7 +14,7 @@ import com.google.common.base.Objects;
 public class Video {
 
 	@Id
-	private long id;
+	private String id;
 
 	private String name;
 	private String url;
@@ -54,11 +54,11 @@ public class Video {
 		this.duration = duration;
 	}
 
-	public long getId() {
+	public String getId() {
 		return id;
 	}
 
-	public void setId(long id) {
+	public void setId(String id) {
 		this.id = id;
 	}
 


### PR DESCRIPTION
MongoDB's auto generated ObjectId consists of alphanumeric characters and hyphens '-'. When a long is used as the datatype for the Id, Spring Data MongoDB will issue an update/overwrite a single document in MongoDB with '_Id': NumberLong(0). 

Output from mongo shell (Id as long):

> db.video.find().pretty()
> {
>     "_id" : NumberLong(0),
>     "_class" : "org.magnum.mobilecloud.video.repository.Video",
>     "name" : "Video-3a3b3158-9517-48c4-bdbd-718374e296bd",
>     "url" : "http://coursera.org/some/video-3a3b3158-9517-48c4-bdbd-718374e296bd",
>     "duration" : NumberLong(2880000)
> }

This differs from the desired outcome which is to create a new (additional) document on subsequent calls to src / test / java / org / magnum / mobilecloud / integration / test / VideoSvcClientApiTest.java

Output from mongo shell (Id as String in 2nd document):

> db.video.find().pretty()
> {
>     "_id" : NumberLong(0),
>     "_class" : "org.magnum.mobilecloud.video.repository.Video",
>     "name" : "Video-3a3b3158-9517-48c4-bdbd-718374e296bd",
>     "url" : "http://coursera.org/some/video-3a3b3158-9517-48c4-bdbd-718374e296bd",
>     "duration" : NumberLong(2880000)
> }
> {
>     "_id" : ObjectId("545cba6444ae69b880ba589b"),
>     "_class" : "org.magnum.mobilecloud.video.repository.Video",
>     "name" : "Video-a820232d-dca3-4754-8962-f5355e408d61",
>     "url" : "http://coursera.org/some/video-a820232d-dca3-4754-8962-f5355e408d61",
>     "duration" : NumberLong(60000)
> }
