### PR TITLE
Updated Video.java and VideoRepository to use String for Id.

### DIFF
--- a/examples/10-VideoServiceWithMongoDB/src/main/java/org/magnum/mobilecloud/video/repository/Video.java
+++ b/examples/10-VideoServiceWithMongoDB/src/main/java/org/magnum/mobilecloud/video/repository/Video.java
@@ -14,7 +14,7 @@ import com.google.common.base.Objects;
 public class Video {
 
 	@Id
-	private long id;
+	private String id;
 
 	private String name;
 	private String url;
@@ -54,11 +54,11 @@ public class Video {
 		this.duration = duration;
 	}
 
-	public long getId() {
+	public String getId() {
 		return id;
 	}
 
-	public void setId(long id) {
+	public void setId(String id) {
 		this.id = id;
 	}
 

--- a/examples/10-VideoServiceWithMongoDB/src/main/java/org/magnum/mobilecloud/video/repository/VideoRepository.java
+++ b/examples/10-VideoServiceWithMongoDB/src/main/java/org/magnum/mobilecloud/video/repository/VideoRepository.java
@@ -26,7 +26,7 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 //    (e.g., /video/search/findByName?title=Foo)
 //
 @RepositoryRestResource(path = VideoSvcApi.VIDEO_SVC_PATH)
-public interface VideoRepository extends MongoRepository<Video, Long>{
+public interface VideoRepository extends MongoRepository<Video, String>{
 
 	// Find all videos with a matching title (e.g., Video.name)
 	public Collection<Video> findByName(


### PR DESCRIPTION
'Id' needs to be String in order for Spring Data JPA to correctly assign an allow MongoDB to automatically generate an ObjectId('...')  and return to Spring Data JPA.
