### PR TITLE
Update README.md

### DIFF
--- a/assignments/Asgn2-VideoLike/README.md
+++ b/assignments/Asgn2-VideoLike/README.md
@@ -222,7 +222,7 @@ official grade.
 ## Hints
 
 - If you want to test your application without security (e.g., to add a simple request mapping
-  and try it without OAuth), you will need to uncomment the following lines in the build.gradle
+  and try it without OAuth), you will need to comment-out the following lines in the build.gradle
   file and then right-click on build.gradle->Refresh All:
 
 ```    


### PR DESCRIPTION
Fix significant typo in "test your application without security" hint.  The old guidance led to "An Authentication object was not found in the SecurityContext".  More info is also available in Jacob Fund's October 28, 2014 thread "Problem authenticating to host", https://class.coursera.org/androidcapstone-001/forum/thread?thread_id=342#post-1384.
